### PR TITLE
Fix WebSocket URL to include session ID parameter

### DIFF
--- a/src/hooks/useMultiGameWebSocket.ts
+++ b/src/hooks/useMultiGameWebSocket.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from 'react';
+import type { UnifiedPersonality, AIActionResponse, GameType } from '../lib/types';
+import { getSessionId } from '../lib/analytics';
+
+interface AnalysisUpdatePayload {
+  updated_personality?: UnifiedPersonality;
+  unified_personality?: UnifiedPersonality;
+  ai_response?: AIActionResponse;
+  game_state?: Record<string, unknown>;
+}
+
+interface IncomingMessageBase {
+  type: string;
+  [k: string]: unknown;
+}
+
+export const useMultiGameWebSocket = (sessionIdProp?: string) => {
+  const [socket, setSocket] = useState<WebSocket | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [gameState, setGameState] = useState<Record<string, unknown>>({});
+  const [personalityData, setPersonalityData] = useState<UnifiedPersonality | null>(null);
+  const [aiResponse, setAiResponse] = useState<AIActionResponse | null>(null);
+  const urlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const sessionId = sessionIdProp || getSessionId();
+    const url = `ws://localhost:8000/ws/multi-game/${sessionId}`;
+    urlRef.current = url;
+    const ws = new WebSocket(url);
+
+    ws.onopen = () => {
+      setConnected(true);
+      setSocket(ws);
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const data: IncomingMessageBase = JSON.parse(event.data);
+        switch (data.type) {
+          case 'connection_established':
+            // No-op; connection state handled onopen
+            break;
+          case 'game_switched': {
+            const state = (data as any).data?.game_state || (data as any).game_state || {};
+            setGameState(state);
+            break;
+          }
+          case 'analysis_update': {
+            const payload: AnalysisUpdatePayload = (data as any).data || (data as any);
+            if (payload.updated_personality || (payload as any).unified_personality) {
+              setPersonalityData(payload.updated_personality || (payload as any).unified_personality || null);
+            }
+            if (payload.ai_response) setAiResponse(payload.ai_response);
+            if (payload.game_state) setGameState(payload.game_state);
+            break;
+          }
+          default:
+            break;
+        }
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('WebSocket message parse error', e);
+      }
+    };
+
+    ws.onclose = () => {
+      setConnected(false);
+      setSocket(null);
+    };
+
+    return () => ws.close();
+  }, [sessionIdProp]);
+
+  const switchGame = (newGame: GameType) => {
+    if (socket && connected) {
+      socket.send(
+        JSON.stringify({
+          type: 'game_switch',
+          new_game: newGame,
+        })
+      );
+    }
+  };
+
+  const sendPlayerAction = (actionData: unknown) => {
+    if (socket && connected) {
+      socket.send(
+        JSON.stringify({
+          type: 'player_action',
+          action: actionData,
+        })
+      );
+    }
+  };
+
+  return { connected, switchGame, sendPlayerAction, gameState, personalityData, aiResponse } as const;
+};

--- a/src/lib/gameActions.ts
+++ b/src/lib/gameActions.ts
@@ -1,0 +1,64 @@
+export type SendPlayerAction = (action: unknown) => void;
+
+export const createGameActionHandlers = (sendPlayerAction: SendPlayerAction) => {
+  const handleFightingAction = (
+    moveType: 'attack' | 'block' | 'move' | 'combo',
+    success: boolean,
+    position: [number, number],
+    damage: number = 0,
+    combo: number = 0
+  ) => {
+    const actionData = {
+      game_type: 'fighting' as const,
+      action_type: moveType,
+      move_type: moveType,
+      success,
+      player_position: position,
+      damage,
+      combo,
+      timestamp: Date.now() / 1000,
+    };
+    sendPlayerAction(actionData);
+  };
+
+  const handleBadmintonAction = (
+    shotType: 'clear' | 'drop' | 'smash' | 'net' | 'drive',
+    targetPos: [number, number],
+    powerLevel: number,
+    rallyCount: number,
+    playerPosition: [number, number]
+  ) => {
+    const actionData = {
+      game_type: 'badminton' as const,
+      action_type: shotType,
+      shot_type: shotType,
+      target: targetPos,
+      power_level: powerLevel,
+      rally_count: rallyCount,
+      player_position: playerPosition,
+      timestamp: Date.now() / 1000,
+    };
+    sendPlayerAction(actionData);
+  };
+
+  const handleRacingAction = (
+    actionType: 'accelerate' | 'brake' | 'steer' | 'overtake',
+    speed: number,
+    position: [number, number],
+    overtaking: boolean = false,
+    crashed: boolean = false
+  ) => {
+    const actionData = {
+      game_type: 'racing' as const,
+      action_type: actionType,
+      speed,
+      player_position: position,
+      overtaking_attempt: overtaking,
+      crash_occurred: crashed,
+      timestamp: Date.now() / 1000,
+    };
+    sendPlayerAction(actionData);
+  };
+
+  return { handleFightingAction, handleBadmintonAction, handleRacingAction } as const;
+};

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -1,12 +1,14 @@
 import { UnifiedPersonality, AIActionResponse } from './types';
+import { getSessionId } from './analytics';
 
 export type WSMessage =
   | { type: 'analysis_update'; unified_personality: UnifiedPersonality; ai_response: AIActionResponse }
   | { type: 'game_switched'; new_game: 'fighting' | 'badminton' | 'racing' }
   | { type: 'session_status'; status: string; [k: string]: unknown };
 
-export const connectMultiGameWS = (onMessage: (msg: WSMessage) => void) => {
-  const ws = new WebSocket('ws://localhost:8000/ws/multi-game');
+export const connectMultiGameWS = (onMessage: (msg: WSMessage) => void, sessionId?: string) => {
+  const sid = sessionId || getSessionId();
+  const ws = new WebSocket(`ws://localhost:8000/ws/multi-game/${sid}`);
   ws.onmessage = (event) => {
     try {
       const data: WSMessage = JSON.parse(event.data);
@@ -20,6 +22,6 @@ export const connectMultiGameWS = (onMessage: (msg: WSMessage) => void) => {
 
 export const sendActionOverWS = (ws: WebSocket | null, action: unknown) => {
   try {
-    ws?.send(JSON.stringify({ type: 'action', action }));
+    ws?.send(JSON.stringify({ type: 'player_action', action }));
   } catch {}
 };


### PR DESCRIPTION
## Purpose

The user was implementing a multi-game WebSocket integration for their React frontend but encountered a URL mismatch issue. The backend WebSocket endpoint expected a `session_id` parameter in the URL path (`/ws/multi-game/{session_id}`), but the frontend connection was missing this parameter, causing connection failures.

## Code changes

- **Added `useMultiGameWebSocket.ts` hook**: Created a comprehensive TypeScript WebSocket hook that properly includes the session ID in the connection URL (`ws://localhost:8000/ws/multi-game/${sessionId}`)
- **Added `gameActions.ts`**: Implemented typed action handlers for fighting, badminton, and racing games with proper data structures
- **Updated `ws.ts`**: Fixed the `connectMultiGameWS` function to accept and use session ID parameter in the WebSocket URL, and corrected the action message type from `'action'` to `'player_action'`

The changes ensure proper WebSocket connectivity by matching the expected backend endpoint structure and provide a robust, type-safe foundation for multi-game interactions.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0f3d3ddcf9694dfaa43db71901de1c0c/pulse-home)

👀 [Preview Link](https://0f3d3ddcf9694dfaa43db71901de1c0c-pulse-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0f3d3ddcf9694dfaa43db71901de1c0c</projectId>-->
<!--<branchName>pulse-home</branchName>-->